### PR TITLE
Remove logic that forces end turn after command

### DIFF
--- a/src/Controller/GameController.java
+++ b/src/Controller/GameController.java
@@ -124,12 +124,7 @@ public class GameController {
 
         // Update player detail panel
         view.getPlayerDetailPanel().setDisplay(game.getCurrentPlayer());
-
-
-        //Checks if the player has any actions left
-        if (!canRoll && !canBuy) {
-            nextPlayer();
-        }
+        
     }
 
     /**********************************************************************


### PR DESCRIPTION
Old model had player turn force ended if they rolled and bought not allowing them to build. I simply got rid of that force.